### PR TITLE
Fix invalid type error in docker-compose YAML

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ store:
     image: postgres:latest # reuse postgres container
     volumes:
         - /var/lib/postgresql/data
-    command: true
+    command: "true"
 
 postgres:
     image: postgres:latest
@@ -31,7 +31,7 @@ proxy:
         - "80:80" # host:container
         - "443:443"
     volumes:
-        - nginx.conf:/etc/nginx/nginx.conf:ro
+        - ./nginx.conf:/etc/nginx/nginx.conf:ro
         # connect host's ./nginx.conf with container's nginx.conf
         # :ro == read only perms in container
     links:


### PR DESCRIPTION
hi there! Docker must have updated the compose file requirements, as this wasn't building anymore. I made a couple changes so it'll build again. 